### PR TITLE
Update entap database and remove Gene Ontology levels

### DIFF
--- a/entap_config.ini
+++ b/entap_config.ini
@@ -110,16 +110,9 @@ output-format=1,3,4,5,6,
 #Note: it is possible to specify more than one! Just usemultiple --ontology flags
 #Specify flags as follows:
 #    0. EggNOG (default)
-#    1. InterProScan 
+#    1. InterProScan
 #type:list (integer)
 ontology=0,
-#Specify the Gene Ontology levels you would like printed
-#A level of 0 means that every term will be printed, while a level of 1 or higher
-#means that that level and anything higher than it will be printed
-#It is possible to specify multiple flags as well
-#Example/Defaults: --level 0 --level 1
-#type:list (integer)
-level=0,1,
 #-------------------------------
 # [ontology-eggnog]
 #-------------------------------
@@ -161,7 +154,7 @@ protein=
 #-------------------------------
 #Method to execute DIAMOND. This can be a path to the executable or simply 'diamond' if installed globally.
 #type:string
-diamond-exe=/libs/diamond-0.9.9/bin/diamond
+diamond-exe=/libs/diamond-2.1.8/bin/diamond
 #Specify the type of species/taxon you are analyzing and would like alignments closer in taxonomic relevance to be favored (based on NCBI Taxonomic Database)
 #Note: replace all spaces with underscores '_'
 #type:string

--- a/src/QueryData.cpp
+++ b/src/QueryData.cpp
@@ -679,8 +679,11 @@ bool QueryData::start_alignment_files(const std::string &base_path, const std::v
                     // For TSV,CSV we want to create a new file for every go level
                     case FileSystem::ENT_FILE_DELIM_TSV:
                     case FileSystem::ENT_FILE_DELIM_CSV:
+                        /* Remove Gene Ontology levels for now
                         final_file_path = base_path + APPEND_GO_LEVEL_STR +
                                 std::to_string(level) + mpFileSystem->get_extension(type);
+                        */
+                        final_file_path = base_path + mpFileSystem->get_extension(type);
                         mAlignmentFiles.at(base_path).file_streams[type][level] =
                                 new std::ofstream(final_file_path, std::ios::out | std::ios::app);
                         initialize_file(mAlignmentFiles.at(base_path).file_streams[type][level],
@@ -701,9 +704,12 @@ bool QueryData::start_alignment_files(const std::string &base_path, const std::v
                         break;
 
                     case FileSystem::ENT_FILE_GENE_ENRICH_EFF_LEN:
+                        /*  Remove GO level data for now
                         final_file_path = base_path + APPEND_GO_LEVEL_STR +
                                           std::to_string(level) + APPEND_ENRICH_GENE_ID_LEN +
                                           mpFileSystem->get_extension(type);
+                        */
+                        final_file_path = base_path + APPEND_ENRICH_GENE_ID_LEN + mpFileSystem->get_extension(type);
                         mAlignmentFiles.at(base_path).file_streams[type][level] =
                                 new std::ofstream(final_file_path, std::ios::out | std::ios::app);
                         initialize_file(mAlignmentFiles.at(base_path).file_streams[type][level],
@@ -711,9 +717,12 @@ bool QueryData::start_alignment_files(const std::string &base_path, const std::v
                         break;
 
                     case FileSystem::ENT_FILE_GENE_ENRICH_GO_TERM:
+                        /*
                         final_file_path = base_path + APPEND_GO_LEVEL_STR +
                                           std::to_string(level) + APPEND_ENRICH_GENE_ID_GO +
                                           mpFileSystem->get_extension(type);
+                        */
+                        final_file_path = base_path + APPEND_ENRICH_GENE_ID_GO + mpFileSystem->get_extension(type);
                         mAlignmentFiles.at(base_path).file_streams[type][level] =
                                 new std::ofstream(final_file_path, std::ios::out | std::ios::app);
                         initialize_file(mAlignmentFiles.at(base_path).file_streams[type][level],

--- a/src/UserInput.cpp
+++ b/src/UserInput.cpp
@@ -352,7 +352,7 @@ const std::string UserInput::ENTAP_INI_FILENAME         = "entap_config.ini";
 const vect_uint16_t UserInput::DEFAULT_DATA_TYPE        = vect_uint16_t{EntapDatabase::ENTAP_SERIALIZED};
 const std::string UserInput::DEFAULT_STATE              ="+";
 const uint16 UserInput::DEFAULT_FRAME_SELECTION         = FRAME_TRANSDECODER;
-const vect_uint16_t UserInput::DEFAULT_ONT_LEVELS       =vect_uint16_t{0,1};
+const vect_uint16_t UserInput::DEFAULT_ONT_LEVELS       =vect_uint16_t{0};
 const vect_uint16_t UserInput::DEFAULT_ONTOLOGY         =vect_uint16_t{ONT_EGGNOG_DMND};
 
 const uint16      UserInput::DEFAULT_TRANSDECODER_MIN_PROTEIN = 100;
@@ -466,7 +466,7 @@ UserInput::EntapINIEntry UserInput::mUserInputs[] = {
 
 /* Ontology Commands */
         {INI_ONTOLOGY  ,CMD_ONTOLOGY_FLAG        ,ENTAP_INI_NULL  ,DESC_ONTOLOGY_FLAG         ,ENTAP_INI_NULL   ,ENT_INI_VAR_MULTI_INT   ,DEFAULT_ONTOLOGY       ,ENT_INI_FILE, ENTAP_INI_NULL_VAL},
-        {INI_ONTOLOGY  ,CMD_GO_LEVELS            ,ENTAP_INI_NULL  ,DESC_ONT_LEVELS            ,ENTAP_INI_NULL   ,ENT_INI_VAR_MULTI_INT   ,DEFAULT_ONT_LEVELS     ,ENT_INI_FILE, ENTAP_INI_NULL_VAL},
+        {INI_ONTOLOGY  ,CMD_GO_LEVELS            ,ENTAP_INI_NULL  ,DESC_ONT_LEVELS            ,ENTAP_INI_NULL   ,ENT_INI_VAR_MULTI_INT   ,DEFAULT_ONT_LEVELS     ,ENT_INPUT_FUTURE, ENTAP_INI_NULL_VAL},
 
 /* Ontology - EggNOG Commands */
         {INI_ONT_EGGNOG,CMD_EGGNOG_SQL           ,ENTAP_INI_NULL  ,DESC_EGGNOG_SQL            ,ENTAP_INI_NULL   ,ENT_INI_VAR_STRING      ,DEFAULT_EGG_SQL_DB_INI ,ENT_INI_FILE, ENTAP_INI_NULL_VAL},
@@ -968,7 +968,7 @@ UserInput::EntapINIEntry* UserInput::check_ini_key(std::string &key) {
             // Ensure it is a command line argument
             if (entry->input_type == ENT_COMMAND_LINE) {
 
-                if (entry->category == INI_ENTAP_API) {
+                if ((entry->category == INI_ENTAP_API) && (arg->isSet())) {
                     mHasAPICmd = true;
                 }
 

--- a/src/database/EntapDatabase.h
+++ b/src/database/EntapDatabase.h
@@ -383,9 +383,7 @@ private:
 
     // FTP Paths
     const std::string FTP_GO_DATABASE =
-            "http://archive.geneontology.org/latest-full/go_monthly-termdb-tables.tar.gz";
-//    const std::string FTP_GO_DATABASE =
-//            "http://archive.geneontology.org/latest-termdb/go_daily-termdb-tables.tar.gz";
+            "http://current.geneontology.org/ontology/go.obo";
     const std::string FTP_NCBI_TAX_DUMP_TARGZ =
             "ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz";
     const std::string FTP_ENTAP_DATABASE_SQL    =
@@ -437,15 +435,7 @@ private:
     const std::string SQL_TABLE_VERSION_COL_VER  = "VERSION";
 
     // Gene Ontology constants
-    const std::string GO_BIOLOGICAL_LVL = "6679";
-    const std::string GO_MOLECULAR_LVL  = "2892";
-    const std::string GO_CELLULAR_LVL   = "311";
-    const std::string GO_TERM_FILE      = "term.txt";
-    const std::string GO_GRAPH_FILE     = "graph_path.txt";
-//    const std::string GO_TERMDB_FILE    = "go_daily-termdb-tables.tar.gz";
-    const std::string GO_TERMDB_FILE    = "go_monthly-termdb-tables.tar.gz";
-//    const std::string GO_TERMDB_DIR     = "go_daily-termdb-tables/";
-    const std::string GO_TERMDB_DIR     = "go_monthly-termdb-tables/";
+    const std::string GO_TERMDB_FILE    = "go.obo";
 
     // UniProt mapping constants
     const std::string UNIPROT_DAT_FILE_GZ            = "uniprot_sprot.dat.gz";


### PR DESCRIPTION
Merge in changes to EnTAP database to fix issue with Gene Ontology formatting changes preventing creation of database. Remove Gene Ontology levels from output and user input